### PR TITLE
two minor issues

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,7 +41,6 @@ jobs:
         # Build and tag the image
         docker build \
           -t $CONTAINER_IMAGE \
-          -t $GITHUB_REPOSITORY:$GITHUB_SHA \
           -t $AWS_ACCOUNT_ID.dkr.ecr.$AWS_DEFAULT_REGION.amazonaws.com/$CONTAINER_IMAGE ./app
            
     # Add additional steps here like scanning of image

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ An example workflow that uses [GitHub Actions](https://help.github.com/en/catego
 1. Set up Flux on the cluster, e.g. using [this guide](https://docs.fluxcd.io/en/latest/tutorials/get-started.html). Note that you must set `--git-path` to point to where your manifests are. For example:
 ```bash
 export GHUSER=<github user account where your fork lives>
+export GHORG=<github org if repo is in an org, othewise github user again>
 export GHREPO=example-actions-flux-eks
 
 kubectl create ns flux
@@ -15,7 +16,7 @@ kubectl create ns flux
 fluxctl install \
     --git-user=${GHUSER} \
     --git-email=${GHUSER}@users.noreply.github.com \
-    --git-url=git@github.com:${GHUSER}/${GHREPO} \
+    --git-url=git@github.com:${GHORG}/${GHREPO} \
     --git-path=manifests \
     --namespace=flux | kubectl apply -f -
 ```

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ kubectl create ns flux
 fluxctl install \
     --git-user=${GHUSER} \
     --git-email=${GHUSER}@users.noreply.github.com \
-    --git-url=git@github.com:${GHORG}/${GHREPO} \
+    --git-url=git@github.com:${GHOWNER}/${GHREPO} \
     --git-path=manifests \
     --namespace=flux | kubectl apply -f -
 ```

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ An example workflow that uses [GitHub Actions](https://help.github.com/en/catego
 1. Create an EKS cluster, e.g. using [`eksctl create cluster`](https://eksctl.io/)
 1. Set up Flux on the cluster, e.g. using [this guide](https://docs.fluxcd.io/en/latest/tutorials/get-started.html). Note that you must set `--git-path` to point to where your manifests are. For example:
 ```bash
-export GHUSER=<github user account where your fork lives>
+export GHOWNER=<github user or organization account where your fork lives>
 export GHORG=<github org if repo is in an org, othewise github user again>
 export GHREPO=example-actions-flux-eks
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,6 @@ An example workflow that uses [GitHub Actions](https://help.github.com/en/catego
 1. Set up Flux on the cluster, e.g. using [this guide](https://docs.fluxcd.io/en/latest/tutorials/get-started.html). Note that you must set `--git-path` to point to where your manifests are. For example:
 ```bash
 export GHOWNER=<github user or organization account where your fork lives>
-export GHORG=<github org if repo is in an org, othewise github user again>
 export GHREPO=example-actions-flux-eks
 
 kubectl create ns flux


### PR DESCRIPTION
1. Flux script (in README) did not handle it if github repo was under an organization (not a username). 
2. The Docker image was tagged in the build process with a name that could have had uppercase characters in it (not allowed in docker image names). Since this tag does not seem to be used anywhere, I removed it. 